### PR TITLE
Fix the GitHub action to add error report to commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,12 @@ jobs:
       run: |
         pytest --maxfail=1 --disable-warnings > last_test_attempt_report.txt || true
         cat last_test_attempt_report.txt
+
+    - name: Commit and push test report
+      if: failure()
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git add last_test_attempt_report.txt
+        git commit -m "Add last test attempt report"
+        git push

--- a/README.md
+++ b/README.md
@@ -66,3 +66,9 @@ pyGameEngine/
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## GitHub Actions
+
+This project includes a GitHub action that runs unit tests on every push and pull request. If the tests fail, the action generates a test report file `last_test_attempt_report.txt` and commits it to the repository. The action then pushes the commit with the report file to the remote repository.
+
+The purpose of this action is to provide immediate feedback on test failures and ensure that the test report is available in the repository for further analysis.


### PR DESCRIPTION
Add steps to commit and push test report in GitHub action

* **README.md**
  - Add a new section "GitHub Actions" to describe the new GitHub action.
  - Mention the purpose of the action and how it works.

* **.github/workflows/test.yml**
  - Add a new step to commit the generated report file to the repository.
  - Add a new step to push the commit with the report file to the remote repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JorchRL/pyGameEngine/pull/5?shareId=93e4202d-820e-4e13-bc55-4a533681b9a6).